### PR TITLE
Switch muon SF correction test to tight ID

### DIFF
--- a/configs/tests/corrections/muon_sf/config.py
+++ b/configs/tests/corrections/muon_sf/config.py
@@ -46,7 +46,7 @@ cfg = Configurator(
 
     weights = {
         "common": {
-            "inclusive": ["sf_mu_iso"],
+            "inclusive": ["sf_mu_id"],
             "bycategory" : {
             }
         },

--- a/configs/tests/corrections/muon_sf/params/lepton_scale_factors.yaml
+++ b/configs/tests/corrections/muon_sf/params/lepton_scale_factors.yaml
@@ -2,25 +2,25 @@ lepton_scale_factors:
   muon_sf:
     sf_name:
       '2016_PreVFP':
-          iso: NUM_TightRelIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2016_PostVFP':
-          iso: NUM_TightRelIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2017':
-          iso: NUM_TightRelIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2018':
-          iso: NUM_TightRelIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2022_preEE':
-          iso: NUM_TightPFIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2022_postEE':
-          iso: NUM_TightPFIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
 
       '2023_preBPix':
-          iso: NUM_TightPFIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons
           
       '2023_postBPix':
-          iso: NUM_TightPFIso_DEN_MediumID
+          id: NUM_TightID_DEN_TrackerMuons

--- a/configs/tests/corrections/muon_sf/workflow.py
+++ b/configs/tests/corrections/muon_sf/workflow.py
@@ -12,10 +12,11 @@ class MuonProcessor(BaseProcessorABC):
 
     def apply_object_preselection(self, variation):
         '''
-        Cleaning only Electrons
+        Cleaning only Muons
         '''
         muon_mask = ((self.events.Muon.pt >= self.params.object_preselection.Muon.pt) & 
-                    (abs(self.events.Muon.eta) <= self.params.object_preselection.Muon.eta))
+                    (abs(self.events.Muon.eta) <= self.params.object_preselection.Muon.eta) &
+                    self.events.Muon.tightId)
         self.events["MuonGood"] = self.events.Muon[muon_mask]
         
 


### PR DESCRIPTION
To improve compatibility between frameworks, one needs to apply a muon ID (randomly picked Tight) and only compute the SF for muons passing the selection. Instead of checking isolation, switch to checking the Tight ID scale factors.

See https://gitlab.cern.ch/cms-analysis/general/analysis_recipes/-/issues/4

Note: the [analysis_recipes](https://gitlab.cern.ch/cms-analysis/general/analysis_recipes) repo still expects the test to be based on the isolation SF